### PR TITLE
修复 kops v1.10.0 使用 calico 的版本错误

### DIFF
--- a/mirror/required-images.txt
+++ b/mirror/required-images.txt
@@ -34,6 +34,8 @@ gcr.io/heptio-images/authenticator:v0.3.0
 quay.io/coreos/flannel:v0.10.0-amd64
 quay.io/calico/node:v3.2.3
 quay.io/calico/cni:v3.2.3
+quay.io/calico/node:v2.6.7
+quay.io/calico/cni:v1.11.2
 
 # Nginx Ingress
 gcr.io/google_containers/defaultbackend:1.4

--- a/mirror/required-images.txt
+++ b/mirror/required-images.txt
@@ -32,10 +32,13 @@ gcr.io/google_containers/kube-apiserver:v1.10.6
 gcr.io/heptio-images/authenticator:v0.3.0
 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:1.0.0
 quay.io/coreos/flannel:v0.10.0-amd64
+
+# calico cni
 quay.io/calico/node:v3.2.3
 quay.io/calico/cni:v3.2.3
 quay.io/calico/node:v2.6.7
 quay.io/calico/cni:v1.11.2
+quay.io/calico/kube-controllers:v1.0.3
 
 # Nginx Ingress
 gcr.io/google_containers/defaultbackend:1.4


### PR DESCRIPTION
kops v1.10.0 中使用的 calico-node 镜像为 quay.io/calico/node:v2.6.7，calico-cni 镜像为 quay.io/calico/cni:v1.11.2