### PR TITLE
Update default etcdv2 to etcdv3

### DIFF
--- a/spec.yml
+++ b/spec.yml
@@ -6,3 +6,22 @@ spec:
     logDriver: ""
     registryMirrors:
         - https://registry.docker-cn.com
+  etcdClusters:
+  - etcdMembers:
+    - instanceGroup: master-cn-north-1a-1
+      name: a-1
+    - instanceGroup: master-cn-north-1b-1
+      name: b-1
+    - instanceGroup: master-cn-north-1a-2
+      name: a-2
+    name: main
+    version: 3.2.18
+  - etcdMembers:
+    - instanceGroup: master-cn-north-1a-1
+      name: a-1
+    - instanceGroup: master-cn-north-1b-1
+      name: b-1
+    - instanceGroup: master-cn-north-1a-2
+      name: a-2
+    name: events
+    version: 3.2.18


### PR DESCRIPTION
Since etcdv2 will officially be deprecated and current version v2.2.1 is hard to upgrade to v3 as tested many times;

Therefore, I think we may use etcdv3 as default;