### PR TITLE
adding `sort -u` to ${repos} and removing exit code check

### DIFF
--- a/mirror/fileRepository/mirror.sh
+++ b/mirror/fileRepository/mirror.sh
@@ -33,30 +33,25 @@ mirror_kubeupv2(){
         if [[ ! -d $TMPDIR/$platform/amd64 ]]; then
         mkdir -p $TMPDIR/$platform/amd64
         fi
-        if [[ ! -d $TMPDIR/images ]]; then
-        mkdir -p $TMPDIR/images
-        fi
+        wget -c https://kubeupv2.s3.amazonaws.com/kops/$KOPS_VERSION/$platform/amd64/kops -O $TMPDIR/$platform/amd64/kops
+        wget -c https://kubeupv2.s3.amazonaws.com/kops/$KOPS_VERSION/$platform/amd64/kops.sha1 -O $TMPDIR/$platform/amd64/kops.sha1
     done
 
 
-    for i in nodeup utils.tar.gz kops
+    for file in nodeup utils.tar.gz
     do
-    for platform in linux darwin
-    do
-        wget -c https://kubeupv2.s3.amazonaws.com/kops/$KOPS_VERSION/$platform/amd64/$i -O $TMPDIR/$platform/amd64/$i
-        wget -c https://kubeupv2.s3.amazonaws.com/kops/$KOPS_VERSION/$platform/amd64/$i.sha1 -O $TMPDIR/$platform/amd64/$i.sha1
-    done
+        wget -c https://kubeupv2.s3.amazonaws.com/kops/$KOPS_VERSION/linux/amd64/$file -O $TMPDIR/linux/amd64/$file
+        wget -c https://kubeupv2.s3.amazonaws.com/kops/$KOPS_VERSION/linux/amd64/$file.sha1 -O $TMPDIR/linux/amd64/$file.sha1
     done
 
-    for platform in linux darwin
-    do
-    aws --profile bjs s3 sync $TMPDIR/$platform/amd64/ s3://kubeupv2/kops/$KOPS_VERSION/$platform/amd64/ --acl public-read
-    done
+    if [[ ! -d $TMPDIR/images ]]; then
+    mkdir -p $TMPDIR/images
+    fi
 
     p=protokube.tar.gz
     wget -c https://kubeupv2.s3.amazonaws.com/kops/$KOPS_VERSION/images/$p -O $TMPDIR/images/$p
     wget -c https://kubeupv2.s3.amazonaws.com/kops/$KOPS_VERSION/images/$p.sha1 -O $TMPDIR/images/$p.sha1
-    aws --profile bjs s3 sync $TMPDIR/images/ s3://kubeupv2/kops/$KOPS_VERSION/images/ --acl public-read
+    aws --profile bjs s3 sync $TMPDIR/ s3://kubeupv2/kops/$KOPS_VERSION/ --acl public-read
 }
 
 

--- a/mirror/mirror-images.sh
+++ b/mirror/mirror-images.sh
@@ -97,8 +97,7 @@ function pull_and_push(){
   echo "$digests"
   echo "checking if remote image exists"
 
-  is_remote_image_exists $target_img $digests
-  if [ $? -eq 0 ];then 
+  if is_remote_image_exists $target_img $digests;then 
     echo "[SKIP] image already exists, skip"
   else
     echo "[PUSH] remote image not exists or digests not match, pushing $target_img"
@@ -113,7 +112,7 @@ function pull_and_push(){
 # list all existing repos
 all_ecr_repos=$(aws --profile=bjs --region $ECR_REGION ecr describe-repositories --query 'repositories[*].repositoryName' --output text)
 echo "$all_ecr_repos"
-repos=$(grep -v ^# $IMAGES_FILE_LIST | cut -d: -f1)
+repos=$(grep -v ^# $IMAGES_FILE_LIST | cut -d: -f1 | sort -u)
 for r in ${repos[@]}
 do
   if need_trim $r; then


### PR DESCRIPTION
`if` in [bash already evaluates if the return status is 0](http://tldp.org/LDP/Bash-Beginners-Guide/html/sect_07_01.html).
`sort -u` will take care of possible repeated repos when trying to mirror multiple image versions.