### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,3 +88,20 @@ update-cluster:
 	AWS_REGION=$(AWS_REGION) \
 	AWS_DEFAULT_REGION=$(AWS_DEFAULT_REGION) \
 	kops delete cluster --name $(CLUSTER_NAME) --yes
+	
+.PHONY: rolling-update-cluster
+rolling-update-cluster:
+	@KOPS_STATE_STORE=$(KOPS_STATE_STORE) \
+	AWS_PROFILE=$(AWS_PROFILE) \
+        AWS_REGION=$(AWS_REGION) \
+        AWS_DEFAULT_REGION=$(AWS_DEFAULT_REGION) \
+        kops rolling-update cluster --name $(CLUSTER_NAME) --yes --cloudonly
+
+
+.PHONY: get-cluster
+get-cluster:
+	@KOPS_STATE_STORE=$(KOPS_STATE_STORE) \
+        AWS_PROFILE=$(AWS_PROFILE) \
+        AWS_REGION=$(AWS_REGION) \
+        AWS_DEFAULT_REGION=$(AWS_DEFAULT_REGION) \
+        kops get cluster --name $(CLUSTER_NAME)


### PR DESCRIPTION
As some of our customer may edit wrong in "make edit-cluster" step or they need to update their cluster, so they need rolling update options. Also, if they choose use makefile to doing their kops operation, we my better list all operations so that they have no need to maintain another set of Environment variable.