### PR TITLE
Update required-images.txt

### DIFF
--- a/mirror/required-images.txt
+++ b/mirror/required-images.txt
@@ -34,6 +34,8 @@ quay.io/calico/node:v2.6.12
 quay.io/calico/cni:v1.11.8
 quay.io/calico/kube-controllers:v1.0.5
 quay.io/calico/kube-policy-controller:v0.7.0
+quay.io/calico/cni:v1.11.5
+quay.io/calico/node:v2.6.9
 
 # Nginx Ingress
 gcr.io/google_containers/defaultbackend:1.4


### PR DESCRIPTION
to get a cluster working with calico and etcd is require this versions. (quay.io/calico/cni:v1.11.5 / quay.io/calico/node:v2.6.9)