### PR TITLE
Update required-images.txt

### DIFF
--- a/mirror/required-images.txt
+++ b/mirror/required-images.txt
@@ -36,6 +36,7 @@ quay.io/calico/kube-controllers:v1.0.5
 quay.io/calico/kube-policy-controller:v0.7.0
 quay.io/calico/cni:v1.11.5
 quay.io/calico/node:v2.6.9
+quay.io/calico/upgrade:v1.0.5
 
 # Nginx Ingress
 gcr.io/google_containers/defaultbackend:1.4


### PR DESCRIPTION
quay.io/calico/calico-upgrade:v1.0.5 is now available and need for "calico" if you are using etcd v3 as "initContainer" Image.