### PR TITLE
Update required-images.txt

### DIFF
--- a/mirror/required-images.txt
+++ b/mirror/required-images.txt
@@ -12,7 +12,7 @@
 #gcr.io/google_containers/etcd:2.2.1
 
 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.5.3
-
+k8s.gcr.io/coredns:1.3.1
 
 
 


### PR DESCRIPTION
Image required with kops 1.12.3 when setting:
```
  kubeDNS:
    provider: CoreDNS
```