### PR TITLE
Added one more docker required  image

### DIFF
--- a/mirror/required-images.txt
+++ b/mirror/required-images.txt
@@ -23,6 +23,7 @@ k8s.gcr.io/coredns:1.3.1
 quay.io/calico/node:v3.7.4
 quay.io/calico/kube-controllers:v3.7.4
 quay.io/calico/cni:v3.7.4
+k8s.gcr.io/pause-amd64:3.0
 
 # Required for k8s cluster backup/restore
 gcr.io/heptio-images/velero:v1.1.0


### PR DESCRIPTION
Hello Team,

I am building a new cluster in china and facing some issues with this image. I think this should be inside the required images. 

Error output
```
failed: rpc error: code = Unknown desc = failed pulling image \"k8s.gcr.io
/pause-amd64:3.0\": Error response from daemon: Get https://k8s.gcr.io/v2/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awai
ting headers)"
```
